### PR TITLE
Update Dockerfile for pwn

### DIFF
--- a/b1/Dockerfile
+++ b/b1/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage
+FROM phusion/baseimage:master-amd64
 
 RUN sed -i "s/http:\/\/archive.ubuntu.com/http:\/\/mirrors.aliyun.com/g" /etc/apt/sources.list
 RUN apt-get update && apt-get -y dist-upgrade


### PR DESCRIPTION
pwn靶机的docker拉取失败，参考https://github.com/allan-simon/docker-dev-rust/issues/8可解决